### PR TITLE
tests: use assert_eq! instead of a simple assert!

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,6 @@ mod tests {
 
     #[test]
     fn starts_with_lorem_ipsum() {
-        assert!(lipsum().starts_with("Lorem ipsum"));
+        assert_eq!(&lipsum()[..11], "Lorem ipsum");
     }
 }


### PR DESCRIPTION
This gives better error messages in case of a mismatch.