### PR TITLE
Use static Markov chain for lipsum calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ license = "MIT"
 
 [dependencies]
 rand = "0.3"
+lazy_static = "0.2"

--- a/benches/generate.rs
+++ b/benches/generate.rs
@@ -1,0 +1,15 @@
+#![feature(test)]
+extern crate test;
+extern crate lipsum;
+
+use test::Bencher;
+
+#[bench]
+fn generate_lorem_ipsum_100(b: &mut Bencher) {
+    b.iter(|| lipsum::lipsum(100))
+}
+
+#[bench]
+fn generate_lorem_ipsum_200(b: &mut Bencher) {
+    b.iter(|| lipsum::lipsum(200))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 extern crate rand;
 
+#[macro_use]
+extern crate lazy_static;
+
 use std::collections::HashMap;
 use rand::Rng;
 
@@ -97,6 +100,16 @@ const LOREM_IPSUM: &str = include_str!("lorem-ipsum.txt");
 /// [`LOREM_IPSUM`]: constant.LOREM_IPSUM.html
 const LIBER_PRIMUS: &str = include_str!("liber-primus.txt");
 
+lazy_static! {
+    /// Markov chain generating lorem ipsum text.
+    static ref LOREM_IPSUM_CHAIN: MarkovChain<'static> = {
+        let mut chain = MarkovChain::new();
+        chain.learn(LOREM_IPSUM);
+        chain.learn(LIBER_PRIMUS);
+        chain
+    };
+}
+
 /// Generate `n` words of lorem ipsum text. The output starts with
 /// "Lorem ipsum" and continues with the standard lorem ipsum text
 /// from [`LOREM_IPSUM`]. The text will become random if sufficiently
@@ -104,10 +117,7 @@ const LIBER_PRIMUS: &str = include_str!("liber-primus.txt");
 ///
 /// [`LOREM_IPSUM`]: constant.LOREM_IPSUM.html
 pub fn lipsum(n: usize) -> String {
-    let mut chain = MarkovChain::new();
-    chain.learn(LOREM_IPSUM);
-    chain.learn(LIBER_PRIMUS);
-    chain.generate_from(n, ("Lorem", "ipsum"))
+    LOREM_IPSUM_CHAIN.generate_from(n, ("Lorem", "ipsum"))
 }
 
 


### PR DESCRIPTION
This introduces a lazily initialized static variable `LOREM_IPSUM_CHAIN` which is initialized the first time `lipsum` is called. This makes it much faster to generate lorem ipsum text using repeated calls to `lipsum` since the Markov chain is only trained once.