### PR TITLE
Add Markov chain learning benchmarks

### DIFF
--- a/benches/learn.rs
+++ b/benches/learn.rs
@@ -1,0 +1,23 @@
+#![feature(test)]
+
+extern crate test;
+extern crate lipsum;
+
+use test::Bencher;
+
+
+#[bench]
+fn learn_lorem_ipsum(b: &mut Bencher) {
+    b.iter(|| {
+        let mut chain = lipsum::MarkovChain::new();
+        chain.learn(lipsum::LOREM_IPSUM)
+    })
+}
+
+#[bench]
+fn learn_liber_primus(b: &mut Bencher) {
+    b.iter(|| {
+        let mut chain = lipsum::MarkovChain::new();
+        chain.learn(lipsum::LIBER_PRIMUS)
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,14 +124,14 @@ impl<'a> MarkovChain<'a> {
 ///
 /// [Wikipedia]: https://en.wikipedia.org/wiki/Lorem_ipsum
 /// [`LIBER_PRIMUS`]: constant.LIBER_PRIMUS.html
-const LOREM_IPSUM: &str = include_str!("lorem-ipsum.txt");
+pub const LOREM_IPSUM: &str = include_str!("lorem-ipsum.txt");
 
 /// The first book in Cicero's work De finibus bonorum et malorum ("On
 /// the ends of good and evil"). The lorem ipsum text in
 /// [`LOREM_IPSUM`] is derived from part of this text.
 ///
 /// [`LOREM_IPSUM`]: constant.LOREM_IPSUM.html
-const LIBER_PRIMUS: &str = include_str!("liber-primus.txt");
+pub const LIBER_PRIMUS: &str = include_str!("liber-primus.txt");
 
 lazy_static! {
     /// Markov chain generating lorem ipsum text.


### PR DESCRIPTION
This makes the `LOREM_IPSUM` and `LIBER_PRIMUS` constants public -- in case people want to use them from their own programs -- and proceeds to make a small benchmark for training a Markov chain on these variables. That way we can track the time for this and potentially optimize it later.