### PR TITLE
rustfmt: add config file

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,6 @@
+array_layout = "Visual"
+control_style = "Legacy"
+fn_args_layout = "Visual"
+fn_call_style = "Visual"
+generics_indent = "Visual"
+struct_lit_width = 40

--- a/benches/learn.rs
+++ b/benches/learn.rs
@@ -9,15 +9,15 @@ use test::Bencher;
 #[bench]
 fn learn_lorem_ipsum(b: &mut Bencher) {
     b.iter(|| {
-        let mut chain = lipsum::MarkovChain::new();
-        chain.learn(lipsum::LOREM_IPSUM)
-    })
+               let mut chain = lipsum::MarkovChain::new();
+               chain.learn(lipsum::LOREM_IPSUM)
+           })
 }
 
 #[bench]
 fn learn_liber_primus(b: &mut Bencher) {
     b.iter(|| {
-        let mut chain = lipsum::MarkovChain::new();
-        chain.learn(lipsum::LIBER_PRIMUS)
-    })
+               let mut chain = lipsum::MarkovChain::new();
+               chain.learn(lipsum::LIBER_PRIMUS)
+           })
 }


### PR DESCRIPTION
This configuration mostly matches the existing code style, which I
happen to like. Compared to the new style agreed upon in the RFC
process, this style uses more visual layouts.

With the struct_lit_width setting, small struct literals are put onto
a single line.