### PR TITLE
Put the random number generator into the Markov chain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,3 @@ appveyor = { repository = "mgeisler/lipsum" }
 
 [dependencies]
 rand = "0.3"
-lazy_static = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,8 @@ thread_local! {
     // Markov chain generating lorem ipsum text.
     static LOREM_IPSUM_CHAIN: RefCell<MarkovChain<'static, rand::ThreadRng>> = {
         let mut chain = MarkovChain::new();
+        // The cost of learning increases as more and more text is
+        // added, so we start with the smallest text.
         chain.learn(LOREM_IPSUM);
         chain.learn(LIBER_PRIMUS);
         RefCell::new(chain)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,12 @@ impl<'a> MarkovChain<'a> {
         }
     }
 
+    /// Create a new Markov chain that uses the given random number
+    /// generator.
+    pub fn new_with_rng(rng: Box<Rng>) -> MarkovChain<'a> {
+        MarkovChain { map: HashMap::new(), rng: rng }
+    }
+
     /// Add new text to the Markov chain. This can be called several
     /// times to build up the chain.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,24 +50,26 @@ pub type Bigram<'a> = (&'a str, &'a str);
 ///
 /// [Markov chain]: https://en.wikipedia.org/wiki/Markov_chain
 /// [blog post]: https://blakewilliams.me/posts/generating-arbitrary-text-with-markov-chains-in-rust
-pub struct MarkovChain<'a> {
+pub struct MarkovChain<'a, R: Rng> {
     map: HashMap<Bigram<'a>, Vec<&'a str>>,
-    rng: Box<Rng>,
+    rng: R,
 }
 
-impl<'a> MarkovChain<'a> {
+impl<'a> MarkovChain<'a, rand::ThreadRng> {
     /// Create a new Markov chain. It will use a default thread-local
     /// random number generator.
-    pub fn new() -> MarkovChain<'a> {
+    pub fn new() -> MarkovChain<'a, rand::ThreadRng> {
         MarkovChain {
             map: HashMap::new(),
-            rng: Box::new(rand::thread_rng()),
+            rng: rand::thread_rng(),
         }
     }
+}
 
+impl<'a, R: Rng> MarkovChain<'a, R> {
     /// Create a new Markov chain that uses the given random number
     /// generator.
-    pub fn new_with_rng(rng: Box<Rng>) -> MarkovChain<'a> {
+    pub fn new_with_rng(rng: R) -> MarkovChain<'a, R> {
         MarkovChain { map: HashMap::new(), rng: rng }
     }
 
@@ -254,7 +256,7 @@ pub const LIBER_PRIMUS: &'static str = include_str!("liber-primus.txt");
 
 thread_local! {
     // Markov chain generating lorem ipsum text.
-    static LOREM_IPSUM_CHAIN: RefCell<MarkovChain<'static>> = {
+    static LOREM_IPSUM_CHAIN: RefCell<MarkovChain<'static, rand::ThreadRng>> = {
         let mut chain = MarkovChain::new();
         chain.learn(LOREM_IPSUM);
         chain.learn(LIBER_PRIMUS);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub type Bigram<'a> = (&'a str, &'a str);
 /// [blog post]: https://blakewilliams.me/posts/generating-arbitrary-text-with-markov-chains-in-rust
 #[derive(Default)]
 pub struct MarkovChain<'a> {
-    pub map: HashMap<Bigram<'a>, Vec<&'a str>>,
+    map: HashMap<Bigram<'a>, Vec<&'a str>>,
 }
 
 impl<'a> MarkovChain<'a> {
@@ -74,10 +74,10 @@ impl<'a> MarkovChain<'a> {
     ///
     /// let mut chain = MarkovChain::new();
     /// chain.learn("red green blue");
-    /// assert_eq!(chain.map[&("red", "green")], vec!["blue"]);
+    /// assert_eq!(chain.words(("red", "green")), Some(&vec!["blue"]));
     ///
     /// chain.learn("red green yellow");
-    /// assert_eq!(chain.map[&("red", "green")], vec!["blue", "yellow"]);
+    /// assert_eq!(chain.words(("red", "green")), Some(&vec!["blue", "yellow"]));
     /// ```
     pub fn learn(&mut self, sentence: &'a str) {
         let words = sentence.split_whitespace().collect::<Vec<&str>>();
@@ -85,6 +85,23 @@ impl<'a> MarkovChain<'a> {
             let (a, b, c) = (window[0], window[1], window[2]);
             self.map.entry((a, b)).or_insert_with(Vec::new).push(c);
         }
+    }
+
+    /// Get the possible words following the given bigram, or `None`
+    /// if the state is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lipsum::MarkovChain;
+    ///
+    /// let mut chain = MarkovChain::new();
+    /// chain.learn("red green blue");
+    /// assert_eq!(chain.words(("red", "green")), Some(&vec!["blue"]));
+    /// assert_eq!(chain.words(("foo", "bar")), None);
+    /// ```
+    pub fn words(&self, state: Bigram<'a>) -> Option<&Vec<&str>> {
+        self.map.get(&state)
     }
 
     /// Generate `n` words worth of lorem ipsum text. The text will

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,11 +60,7 @@ impl<'a> MarkovChain<'a, rand::ThreadRng> {
     /// Create a new Markov chain. It will use a default thread-local
     /// random number generator.
     pub fn new() -> MarkovChain<'a, rand::ThreadRng> {
-        MarkovChain {
-            map: HashMap::new(),
-            keys: Vec::new(),
-            rng: rand::thread_rng(),
-        }
+        MarkovChain::new_with_rng(rand::thread_rng())
     }
 }
 


### PR DESCRIPTION
The aim of this PR is to make it possible to customize the random number generator used by the Markov chains. If the RNG can be specified by the user, the user can ensure deterministic output, which is useful for testing.