### PR TITLE
emacs: define bug-reference-url-format

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+((nil
+  (bug-reference-bug-regexp . "#\\(?2:[0-9]+\\)")
+  (bug-reference-url-format . "https://github.com/mgeisler/lipsum/issues/%s")))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 keywords = ["lorem-ipsum", "lorem", "ipsum", "text", "typography"]
 categories = ["text-processing"]
 license = "MIT"
+exclude = [".dir-locals.el"]
 
 [badges]
 travis-ci = { repository = "mgeisler/lipsum" }


### PR DESCRIPTION
This lets Emacs highlight issue numbers and link them back to the
GitHub repository.