### PR TITLE
Generate full sentences

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ This is a changelog with the most important changes in each release.
 
 ### Unreleased
 
-Sentences returned from `generate` and `generate_from` now always end
-with `.` or some other punctuation character. Use `iter` directly if
-you want to control this.
+The `generate` and `generate_from` now always generate proper
+sentences, meaning that they generate sentences that start with a
+capital letter and end with `.` or some other punctuation character.
+Use `iter` and `iter_from` directly if you need more control.
 
 ### Version 0.3.0 — July 28th, 2017
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ the same text.
 
 This is a changelog with the most important changes in each release.
 
+### Unreleased
+
+Sentences returned from `generate` and `generate_from` now always end
+with `.` or some other punctuation character. Use `iter` directly if
+you want to control this.
+
 ### Version 0.3.0 — July 28th, 2017
 
 Performance is improved by about 50% when generating text, but

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,8 @@ impl<'a, R: Rng> MarkovChain<'a, R> {
     /// and a `.` will be added as necessary to form a full sentence.
     ///
     /// See [`generate_from`] if you want to control the starting
-    /// point for the generated text.
+    /// point for the generated text and see [`iter`] if you simply
+    /// want a sequence of words.
     ///
     /// # Examples
     ///
@@ -209,6 +210,7 @@ impl<'a, R: Rng> MarkovChain<'a, R> {
     /// > Tock, Tick, Tock, Tick, Tock.
     ///
     /// [`generate_from`]: struct.MarkovChain.html#method.generate_from
+    /// [`iter`]: struct.MarkovChain.html#method.iter
     pub fn generate(&mut self, n: usize) -> String {
         join_words(self.iter().take(n))
     }
@@ -217,9 +219,12 @@ impl<'a, R: Rng> MarkovChain<'a, R> {
     /// sentence will start from the given bigram and a `.` will be
     /// added as necessary to form a full sentence.
     ///
-    /// Use [`generate`] if the starting point is not important.
+    /// Use [`generate`] if the starting point is not important. See
+    /// [`iter_from`] if you want a sequence of words that you can
+    /// format yourself.
     ///
     /// [`generate`]: struct.MarkovChain.html#method.generate
+    /// [`iter_from`]: struct.MarkovChain.html#method.iter_from
     pub fn generate_from(&mut self, n: usize, from: Bigram<'a>) -> String {
         join_words(self.iter_from(from).take(n))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,9 +92,9 @@ impl<'a, R: Rng> MarkovChain<'a, R> {
     /// chain.learn("infra-red red orange yellow green blue indigo x-ray");
     ///
     /// // The chain jumps consistently like this:
-    /// assert_eq!(chain.generate(1), "yellow.");
-    /// assert_eq!(chain.generate(1), "green.");
-    /// assert_eq!(chain.generate(1), "red.");
+    /// assert_eq!(chain.generate(1), "Yellow.");
+    /// assert_eq!(chain.generate(1), "Green.");
+    /// assert_eq!(chain.generate(1), "Red.");
     /// # }
     /// ```
 
@@ -313,14 +313,26 @@ fn is_ascii_punctuation(c: char) -> bool {
     }
 }
 
-/// Join words from an iterator. The generated sentence will end with
-/// `'.'` if it doesn't already end with some other ASCII punctuation
-/// character.
+/// Join words from an iterator. The first word is always capitalized
+/// and the generated sentence will end with `'.'` if it doesn't
+/// already end with some other ASCII punctuation character.
 fn join_words<'a, I: Iterator<Item = &'a str>>(mut words: I) -> String {
     match words.next() {
         None => String::new(),
         Some(word) => {
             let mut sentence = String::from(word);
+
+            // Capitalize first word if necessary.
+            if !sentence.starts_with(|c: char| c.is_uppercase()) {
+                let mut chars = word.chars();
+                if let Some(first) = chars.next() {
+                    sentence.clear();
+                    sentence.extend(first.to_uppercase());
+                    sentence.extend(chars);
+                }
+            }
+
+            // Add remaining words.
             for word in words {
                 sentence.push(' ');
                 sentence.push_str(word);
@@ -428,7 +440,7 @@ mod tests {
         let mut chain = MarkovChain::new();
         chain.learn("red orange yellow green blue indigo violet");
         assert_eq!(chain.generate_from(5, ("orange", "yellow")),
-                   "orange yellow green blue indigo.");
+                   "Orange yellow green blue indigo.");
     }
 
     #[test]
@@ -475,6 +487,6 @@ mod tests {
         chain.learn("foo bar x y z");
         chain.learn("foo bar a b c");
 
-        assert_eq!(chain.generate(15), "a b b x y b x y x y x y bar x y.");
+        assert_eq!(chain.generate(15), "A b b x y b x y x y x y bar x y.");
     }
 }


### PR DESCRIPTION
Before we would just put random words together in the `generate` method. The resulting sentence could easily begin with a lowercase word and end without a full-stop. We now take care to capitalize the first word and will add a `.` as necessary.