### PR TITLE
lib: set html_root_url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 //! [`learn`]: struct.MarkovChain.html#method.learn
 //! [Markov chain]: https://en.wikipedia.org/wiki/Markov_chain
 
+#![doc(html_root_url = "https://docs.rs/lipsum/0.3.0")]
 #![deny(missing_docs)]
 
 extern crate rand;


### PR DESCRIPTION
This is per C-HTML-ROOT in the Rust API Guidelines:
https://rust-lang-nursery.github.io/api-guidelines/documentation.html