### PR TITLE
travis: bump minimum supported Rust version to 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - 1.6.0
+  - 1.8.0
   - stable
   - beta
   - nightly
@@ -10,7 +10,7 @@ cache: cargo
 
 before_install:
   - |
-      if [[ "$TRAVIS_RUST_VERSION" == "1.6.0" ]]; then
+      if [[ "$TRAVIS_RUST_VERSION" == "1.8.0" ]]; then
           echo "Old Rust detected, removing version-sync dependency"
           sed -i "/^version-sync =/d" Cargo.toml
           rm "tests/version-numbers.rs"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ the same text.
 
 This is a changelog with the most important changes in each release.
 
+### Unreleased
+
+The oldest supported version of Rust is now 1.8.
+
 ### Version 0.4.0 — September 24th, 2017
 
 The `generate` and `generate_from` now always generate proper


### PR DESCRIPTION
The rand crate bumped its minimum version with the 0.3.18 release.