### PR TITLE
travis: bump minimum rustc version to 1.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,12 @@
 language: rust
 
 rust:
-  - 1.8.0
+  - 1.17.0
   - stable
   - beta
   - nightly
 
 cache: cargo
-
-before_install:
-  - |
-      if [[ "$TRAVIS_RUST_VERSION" == "1.8.0" ]]; then
-          echo "Old Rust detected, removing version-sync dependency"
-          sed -i "/^version-sync =/d" Cargo.toml
-          rm "tests/version-numbers.rs"
-      fi
 
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ This is a changelog with the most important changes in each release.
 
 ### Unreleased
 
-The oldest supported version of Rust is now 1.8.
+Dependencies were updated and the oldest supported version of Rust is
+now 1.17.
 
 ### Version 0.4.0 — September 24th, 2017
 


### PR DESCRIPTION
This allows us to upgrade to rand 0.4 and to remove a workaround for
testing with version-sync.