### PR TITLE
circleci: generate coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: xd009642/tarpaulin
+    steps:
+      - checkout
+      - run:
+          name: Generate coverage report
+          command: cargo tarpaulin --out Xml
+      - run:
+          name: Upload to codecov.io
+          command: bash <(curl -s https://codecov.io/bash) -Z -f cobertura.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,3 @@ cache: cargo
 matrix:
   allow_failures:
     - rust: nightly
-
-  include:
-    - rust: stable
-      sudo: required
-      cache: off
-      script:
-        - bash <(curl -s https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
-        - cargo tarpaulin --out Xml
-        - bash <(curl -s https://codecov.io/bash) -Z -f cobertura.xml


### PR DESCRIPTION
This moves the coverage generation from Travis CI to CircleCI: we can
run up to four Docker containers at the same time there and they start
really fast.

So this means we can do more things in parallel by spreading the load
over two different CI providers.