### PR TITLE
Update all dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - 1.17.0
+  - 1.21.0
   - stable
   - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - 1.21.0
+  - 1.22.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ appveyor = { repository = "mgeisler/lipsum" }
 codecov = { repository = "mgeisler/lipsum" }
 
 [dependencies]
-rand = "0.4"
+rand = "0.6"
 
 [dev-dependencies]
 version-sync = "0.6"
+rand_xorshift = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ codecov = { repository = "mgeisler/lipsum" }
 rand = "0.4"
 
 [dev-dependencies]
-version-sync = "0.5"
+version-sync = "0.6"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ all words.
 
 This is a changelog with the most important changes in each release.
 
+### Unreleased
+
+Dependencies were updated and the oldest supported version of Rust is
+now 1.21.
+
 ### Version 0.5.0 — April 22nd, 2018
 
 The new `lipsum_title` function can be used to generate a short string

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This is a changelog with the most important changes in each release.
 ### Unreleased
 
 Dependencies were updated and the oldest supported version of Rust is
-now 1.21.
+now 1.22.
 
 ### Version 0.5.0 — April 22nd, 2018
 

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -7,6 +7,11 @@ fn test_readme_deps() {
 }
 
 #[test]
+fn test_readme_changelog() {
+    assert_contains_regex!("README.md", r"^### Version {version} — .* \d\d?.., 20\d\d$");
+}
+
+#[test]
 fn test_html_root_url() {
     assert_html_root_url_updated!("src/lib.rs");
 }


### PR DESCRIPTION
As usual, this means that we now require a newer version of Rust, the minimum version jumped from 1.17 to 1.22.