### PR TITLE
cargo: update version-sync to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ codecov = { repository = "mgeisler/lipsum" }
 rand = "0.6"
 
 [dev-dependencies]
-version-sync = "0.6"
+version-sync = "0.8"
 rand_xorshift = "0.1"


### PR DESCRIPTION
This version is still compatible with Rust 2018.