### PR TITLE
travis: drop beta Rust target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: rust
 
 rust:
-  - 1.31.0
+  - 1.31.0 # Rust 2018
   - stable
-  - beta
   - nightly
 
 cache: cargo


### PR DESCRIPTION
I don't think we've ever seen a build failure on this test target so
it seems like a waste of resources to continuously build it.