### PR TITLE
Drop Rust 1.31 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 
 rust:
-  - 1.31.0 # Rust 2018
   - stable
   - nightly
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ appveyor = { repository = "mgeisler/lipsum" }
 codecov = { repository = "mgeisler/lipsum" }
 
 [dependencies]
-rand = "0.6"
+rand = "0.7"
 
 [dev-dependencies]
-version-sync = "0.8"
-rand_xorshift = "0.1"
+version-sync = "0.9"
+rand_xorshift = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 keywords = ["lorem-ipsum", "lorem", "ipsum", "text", "typography"]
 categories = ["text-processing"]
 license = "MIT"
+edition = "2018"
 exclude = [".dir-locals.el"]
 
 [badges]

--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@ Add this to your `Cargo.toml`:
 lipsum = "0.6"
 ```
 
-and this to your crate root:
-```rust
-extern crate lipsum;
-```
-
-
 ## Documentation
 
 Please see the **[API documentation][api-docs]**.
@@ -44,8 +38,6 @@ Please see the **[API documentation][api-docs]**.
 
 Use the `lipsum` function to generate lorem ipsum text:
 ```rust
-extern crate lipsum;
-
 use lipsum::lipsum;
 
 fn main() {

--- a/README.md
+++ b/README.md
@@ -79,8 +79,15 @@ This is a changelog with the most important changes in each release.
 
 ### Unreleased
 
-We now use [Rust 2018][rust-2018], which means we require Rust version
-1.31.0 or later.
+We now require the [Rust 2018 edition][rust-2018]. Over the years,
+we’ve repeatedly seen build failures in our CI, even when nothing
+changed in `lipsum`. The failures happened because we tested against a
+fixed version of Rust, but our dependencies kept releasing new patch
+it has versions that would push up the minimum required Rust version.
+
+The build failures makes it infeasible to keep `lipsum` compatible
+with any particular version of Rust. We will therefore track the
+latest stable version of Rust from now on.
 
 ### Version 0.6.0 — December 9th, 2018
 

--- a/benches/generate.rs
+++ b/benches/generate.rs
@@ -1,8 +1,6 @@
 #![feature(test)]
 
-extern crate lipsum;
 extern crate test;
-
 use test::Bencher;
 
 #[bench]

--- a/benches/learn.rs
+++ b/benches/learn.rs
@@ -1,8 +1,6 @@
 #![feature(test)]
 
-extern crate lipsum;
 extern crate test;
-
 use test::Bencher;
 
 #[bench]

--- a/examples/lipsum.rs
+++ b/examples/lipsum.rs
@@ -1,5 +1,3 @@
-extern crate lipsum;
-
 use std::env;
 
 fn main() {

--- a/examples/lipsum.rs
+++ b/examples/lipsum.rs
@@ -1,5 +1,3 @@
-use std::env;
-
 fn main() {
     // Generate lorem ipsum text with Title Case.
     let title = lipsum::lipsum_title();
@@ -7,7 +5,7 @@ fn main() {
     println!("{}\n{}\n", title, str::repeat("=", title.len()));
 
     // First command line argument or "" if not supplied.
-    let arg = env::args().nth(1).unwrap_or_default();
+    let arg = std::env::args().nth(1).unwrap_or_default();
     // Number of words to generate.
     let n = arg.parse().unwrap_or(25);
     // Print n words of lorem ipsum text.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ impl<'a, R: Rng> MarkovChain<'a, R> {
 
     /// Make a never-ending iterator over the words in the Markov
     /// chain. The iterator starts at a random point in the chain.
-    pub fn iter(&mut self) -> Words<R> {
+    pub fn iter(&mut self) -> Words<'_, R> {
         let state = if self.is_empty() {
             ("", "")
         } else {
@@ -255,7 +255,7 @@ impl<'a, R: Rng> MarkovChain<'a, R> {
 
     /// Make a never-ending iterator over the words in the Markov
     /// chain. The iterator starts at the given bigram.
-    pub fn iter_from(&mut self, from: Bigram<'a>) -> Words<R> {
+    pub fn iter_from(&mut self, from: Bigram<'a>) -> Words<'_, R> {
         Words {
             map: &self.map,
             rng: &mut self.rng,
@@ -271,7 +271,7 @@ impl<'a, R: Rng> MarkovChain<'a, R> {
 ///
 /// [`iter`]: struct.MarkovChain.html#method.iter
 /// [`iter_from`]: struct.MarkovChain.html#method.iter_from
-pub struct Words<'a, R: 'a + Rng> {
+pub struct Words<'a, R: Rng> {
     map: &'a HashMap<Bigram<'a>, Vec<&'a str>>,
     rng: &'a mut R,
     keys: &'a Vec<Bigram<'a>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,6 @@
 #![doc(html_root_url = "https://docs.rs/lipsum/0.6.0")]
 #![deny(missing_docs)]
 
-extern crate rand;
-#[cfg(test)]
-extern crate rand_xorshift;
-
 use rand::rngs::ThreadRng;
 use rand::seq::SliceRandom;
 use rand::Rng;
@@ -95,10 +91,6 @@ impl<'a, R: Rng> MarkovChain<'a, R> {
     /// # Examples
     ///
     /// ```
-    /// extern crate rand;
-    /// extern crate rand_xorshift;
-    /// # extern crate lipsum;
-    ///
     /// # fn main() {
     /// use rand::SeedableRng;
     /// use rand_xorshift::XorShiftRng;
@@ -498,9 +490,9 @@ pub fn lipsum_title() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::rand::SeedableRng;
-    use super::rand_xorshift::XorShiftRng;
     use super::*;
+    use rand::SeedableRng;
+    use rand_xorshift::XorShiftRng;
 
     #[test]
     fn starts_with_lorem_ipsum() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,10 +111,9 @@ impl<'a, R: Rng> MarkovChain<'a, R> {
     /// // The chain jumps consistently like this:
     /// assert_eq!(chain.generate(1), "Yellow.");
     /// assert_eq!(chain.generate(1), "Blue.");
-    /// assert_eq!(chain.generate(1), "Green.");
+    /// assert_eq!(chain.generate(1), "Orange.");
     /// # }
     /// ```
-
     pub fn new_with_rng(rng: R) -> MarkovChain<'a, R> {
         MarkovChain {
             map: HashMap::new(),
@@ -604,6 +603,6 @@ mod tests {
         chain.learn("foo bar x y z");
         chain.learn("foo bar a b c");
 
-        assert_eq!(chain.generate(15), "A b x y y b y bar a b y x y bar a.");
+        assert_eq!(chain.generate(15), "Bar x y a b x y y b b a b a b bar.");
     }
 }

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,14 +1,11 @@
-#[macro_use]
-extern crate version_sync;
-
 #[test]
 fn test_readme_deps() {
-    assert_markdown_deps_updated!("README.md");
+    version_sync::assert_markdown_deps_updated!("README.md");
 }
 
 #[test]
 fn test_readme_changelog() {
-    assert_contains_regex!(
+    version_sync::assert_contains_regex!(
         "README.md",
         r"^### Version {version} — .* \d\d?.., 20\d\d$"
     );
@@ -16,5 +13,5 @@ fn test_readme_changelog() {
 
 #[test]
 fn test_html_root_url() {
-    assert_html_root_url_updated!("src/lib.rs");
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
 }


### PR DESCRIPTION
Repeated build failures makes it infeasible to keep lipsum compatible
with any particular version of Rust. We will therefore track the
latest stable version of Rust from now on.