### PR TITLE
Add lipsum_words_from_seed helper function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ codecov = { repository = "mgeisler/lipsum" }
 
 [dependencies]
 rand = "0.7"
+rand_chacha = "0.2"
 
 [dev-dependencies]
 version-sync = "0.9"
-rand_xorshift = "0.2"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ The build failures makes it infeasible to keep `lipsum` compatible
 with any particular version of Rust. We will therefore track the
 latest stable version of Rust from now on.
 
+The new `lipsum_words_from_seed` function generates random but
+deterministic lorem ipsum text. This is useful in unit tests when you
+need fixed inputs.
+
 ### Version 0.6.0 — December 9th, 2018
 
 The new `lipsum_words` function can be used to generate random lorem


### PR DESCRIPTION
I noticed that I often need to generate a deterministic string of
random words in unit tests. This helper function does this.

Since we need a concrete RNG for this, `rand_chacha` is now an
explicit dependency of `lipsum`. We already had an indirect dependency
on this crate since `rand` pulls in `rand_chacha` by default.