### PR TITLE
Remove unused [badges] section from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,6 @@ license = "MIT"
 edition = "2018"
 exclude = [".dir-locals.el"]
 
-[badges]
-travis-ci = { repository = "mgeisler/lipsum" }
-appveyor = { repository = "mgeisler/lipsum" }
-codecov = { repository = "mgeisler/lipsum" }
-
 [dependencies]
 rand = "0.8"
 rand_chacha = "0.3"


### PR DESCRIPTION
The badges are no longer shown on crates.io and I don’t think they were ever shown on lib.rs. According to the documentation we should instead rely on the badges in the README.

  https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section