### PR TITLE
Forbid the use of unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 //! [Markov chain]: https://en.wikipedia.org/wiki/Markov_chain
 
 #![doc(html_root_url = "https://docs.rs/lipsum/0.7.0")]
+#![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
 use rand::rngs::ThreadRng;


### PR DESCRIPTION
This is to avoid us accidentally introducing unsafe code and to make the crate show up in green with `cargo geiger`, see

  https://github.com/rust-secure-code/cargo-geiger