### PR TITLE
Add `lipsum_from_seed` and tweak capitalization.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,6 +417,29 @@ pub fn lipsum(n: usize) -> String {
     LOREM_IPSUM_CHAIN.with(|chain| chain.generate_from(n, ("Lorem", "ipsum")))
 }
 
+/// Generate `n` words of lorem ipsum text. The output will always start with
+/// "Lorem ipsum". The seed makes the sequence deterministic.
+///
+/// Deterministic sequences are useful for unit tests where you need random but
+/// consistent inputs or when users expect an infinitely extendable blind text
+/// string that does not change.
+///
+/// # Examples
+///
+/// ```
+/// use lipsum::lipsum_from_seed;
+///
+/// assert_eq!(lipsum_from_seed(23, 16),
+///     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim.");
+/// ```
+///
+/// [`LOREM_IPSUM`]: constant.LOREM_IPSUM.html
+/// [`lipsum`]: fn.lipsum.html
+pub fn lipsum_from_seed(n: usize, seed: u64) -> String {
+    let rng = ChaCha20Rng::seed_from_u64(seed);
+    LOREM_IPSUM_CHAIN.with(|chain| chain.generate_with_rng_from(rng, n, ("Lorem", "ipsum")))
+}
+
 /// Generate `n` random words of lorem ipsum text.
 ///
 /// The text starts with a random word from [`LOREM_IPSUM`]. Multiple
@@ -437,9 +460,12 @@ pub fn lipsum_words(n: usize) -> String {
     LOREM_IPSUM_CHAIN.with(|chain| chain.generate(n))
 }
 
-/// Generate `n` random words of lorem ipsum text. The seed is used to
-/// make the sequence deterministic. This is useful in unit tests
-/// where you need random but consistent inputs.
+/// Generate `n` random words of lorem ipsum text. The seed makes the sequence
+/// deterministic.
+///
+/// Deterministic sequences are useful for unit tests where you need random but
+/// consistent inputs or when users expect an infinitely extendable blind text
+/// string that does not change.
 ///
 /// # Examples
 ///
@@ -630,9 +656,11 @@ mod tests {
             lipsum_words_from_seed(10, 100_000),
             lipsum_words_from_seed(10, 100_000)
         );
+        assert_eq!(lipsum_from_seed(30, 100_000), lipsum_from_seed(30, 100_000));
         assert_ne!(
             lipsum_words_from_seed(10, 100_000),
             lipsum_words_from_seed(10, 100_001)
         );
+        assert_ne!(lipsum_from_seed(30, 100_000), lipsum_from_seed(30, 100_001));
     }
 }


### PR DESCRIPTION
Hey,
thanks for the nice library!

I'm considering using this in one of my projects to allow users to create blind text of arbitrary length. I'd prefer everyone to have the same output for a given length while preserving the iconic start "Lorem ipsum dolor sit amet". Hence, I needed a function combining the properties of `lipsum` and `lipsum_words_from_seed`. I added `lipsum_from_seed` (very easy thanks to great design!) for this purpose and rearranged both its and `lipsum_words_from_seed` doc string a bit as to not make the function overview to wordy.

While implementing the new function, I realized that `lipsum` will sometimes yield strings like `"Nullam habuit. voluptatem cum summum."` containing punctuation followed by non-capitalized words. This did not look very nice to me, so I adjusted `join_words` to always capitalize after a `.`, `?`, or `!`.

I hope these changes align with your plan for the library and match the style used so far. I'm happy to make stylistic changes to the PR!