### PR TITLE
Remove some unnecessary crate tags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,17 +3,17 @@ name = "lipsum"
 version = "0.8.1"
 authors = ["Martin Geisler <martin@geisler.net>"]
 description = """
-Lipsum is a lorem ipsum text generation library. Use this if you need
-filler or dummy text for your application.
+Lipsum is a lorem ipsum text generation library. It generates
+pseudo-random Latin text. Use this if you need filler or dummy text
+for your application.
 
-The text is generated using a simple Markov chain, which you can also
+The text is generated using a simple Markov chain, which you can
 instantiate to generate your own pieces of pseudo-random text.
 """
 documentation = "https://docs.rs/lipsum/"
 repository = "https://github.com/mgeisler/lipsum/"
 readme = "README.md"
-keywords = ["lorem-ipsum", "lorem", "ipsum", "random", "bigram", "markov-chain",
-            "text", "typography"]
+keywords = ["random", "text", "markov", "typography"]
 categories = ["text-processing"]
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
When trying to publish the 0.8.1 release, I found that the number of tags is limited to five on crates.io.