### PR TITLE
Fix build error on Rust 1.56

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@ fn join_words<'a, I: Iterator<Item = &'a str>>(mut words: I) -> String {
         None => String::new(),
         Some(word) => {
             // Punctuation characters which ends a sentence.
-            let punctuation = &['.', '!', '?'];
+            let punctuation: &[char] = &['.', '!', '?'];
 
             let mut sentence = capitalize(word);
             let mut needs_cap = sentence.ends_with(punctuation);


### PR DESCRIPTION
Something changed between Rust 1.57 and 1.58 so that the slice pattern doesn’t work without an explicit type annotation in the earlier version. Without it, we get

```
error[E0277]: expected a `Fn<(char,)>` closure, found `[char; 3]`
   --> src/lib.rs:350:52
    |
350 |             let mut needs_cap = sentence.ends_with(punctuation);
    |                                                    ^^^^^^^^^^^ expected an `Fn<(char,)>` closure, found `[char; 3]`
    |
    = help: the trait `Fn<(char,)>` is not implemented for `[char; 3]`
    = note: required because of the requirements on the impl of `FnOnce<(char,)>` for `&[char; 3]`
    = note: required because of the requirements on the impl of `Pattern<'_>` for `&[char; 3]`
```

Between 1.57 and 1.58, the `Pattern` trait got a new implementation for `[char; N]`, and I guess this somehow made the code work afterwards (even though we’re using a `[char]` here).

The problematic code change was introduced in #75.

Fixes #83.