### PR TITLE
Remove outdated Rust 1.31 badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Lorem Ipsum
 
-[![](https://img.shields.io/crates/v/lipsum.svg)][crates-io]
-[![](https://docs.rs/lipsum/badge.svg)][api-docs]
-[![](https://img.shields.io/badge/rustc-1.31.0-blue.svg)][rust-2018]
 [![](https://travis-ci.org/mgeisler/lipsum.svg?branch=master)][travis-ci]
 [![](https://ci.appveyor.com/api/projects/status/github/mgeisler/lipsum?branch=master&svg=true)][appveyor]
 [![](https://codecov.io/gh/mgeisler/lipsum/branch/master/graph/badge.svg)][codecov]
+[![](https://img.shields.io/crates/v/lipsum.svg)][crates-io]
+[![](https://docs.rs/lipsum/badge.svg)][api-docs]
 
 Lipsum is a small Rust library for generating pseudo-Latin [lorem
 ipsum filler text][lorem ipsum]. This is a standard placeholder text


### PR DESCRIPTION
Back in 2020, I gave up on trying to keep the library compatible with old Rust releases. This was with the 0.7.0 release which gave up compatibility with Rust 1.31 (the first version of the 2018 edition).

Since then, the releases have roughly tracked the latest stable release of Rust, with no particular urgency to bump this of course.

This is related to #83 where @WorldSEnder noticed that Lipsum no longer compiles on Rust 1.56. This was easy to fix (#84), but we should still remove the misleading badge.