### PR TITLE
Use the correct `windows-latest` OS name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
           - nightly
         os:
           - ubuntu-latest
-          - window-latest
+          - windows-latest
         exclude:
           - rust: nightly
-            os: window-latest
+            os: windows-latest
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Strangely, the didn’t cause an error: instead the build would seemingly hang forever saying:

    Requested labels: window-latest
    Job defined at: mgeisler/lipsum/.github/workflows/build.yml@refs/pull/86/merge
    Waiting for a runner to pick up this job...