### PR TITLE
Test minimum supported Rust version (Rust 1.56) in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         rust:
+          - 1.56
           - stable
           - nightly
         os:


### PR DESCRIPTION
This is the first version to support the 2021 edition. I tried tracking the minimum supported Rust version (MSRV) back in 2020, but this turned out to be infeasible because of frequent bumps to the MSRV in our dependencies (see https://github.com/mgeisler/lipsum/commit/9d622ccd23ec0b2ae258270e244cd171290b057d). I hope the update pace has cooled enough to make the feasible again.

I plan to (conservatively) bump this version up as needed going forward. This will of course announcing it in the release notes of new releases.

See https://github.com/mgeisler/lipsum/issues/83 for the motivation.