### PR TITLE
Add `getrandom` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ edition = "2021"
 exclude = [".dir-locals.el"]
 
 [dependencies]
-rand = "0.8.5"
+rand = {version = "0.8.5", default-features = false, features = ["alloc"]}
 rand_chacha = "0.3.1"
 
 [dev-dependencies]
 version-sync = "0.9.4"
+rand = "0.8.5"


### PR DESCRIPTION
As discussed in #74, here is a PR that makes system randomness an optional (but enabled by default) feature.

The catch of this PR is that it interacts badly with the test for the example. `cargo build --no-default-features` works as intended, but `cargo test --no-default-features` will fail unless the code in the main function of `examples/lipsum.rs` is removed. Furthermore, I had to adapt one documentation example such that it would work without `thread_rng`. There are [methods to exclude examples from doctesting depending on the features the crate is built with,](https://users.rust-lang.org/t/doctests-that-require-a-non-default-feature-is-it-possible/29529/4) but they are ugly.

I'd be happy to incorporate any feedback on naming / test architecture. Have a nice day!