### PR TITLE
Run dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     commit-message:
       prefix: cargo
     groups:
@@ -19,4 +19,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
We don’t need weekly updated here since the library has just a few dependencies.