### PR TITLE
Bump MSRV to 1.61 to accommodate our dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Rust
-        run: rustup default 1.56
+      - name: Detect MSRV
+        run: echo MSRV=$(grep 'rust-version' Cargo.toml | cut -d '"' -f 2) >> "$GITHUB_ENV"
+
+      - name: Install Rust  ${{ env.MSRV }}
+        run: rustup default $MSRV
 
       - uses: Swatinem/rust-cache@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["random", "text", "markov", "typography"]
 categories = ["text-processing"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.61"
 
 [dependencies]
 rand = {version = "0.8.5", default-features = false, features = ["alloc"]}


### PR DESCRIPTION
- byteorder v1.5.0 requires 1.60
- ppv-lite86 v0.2.20 requires 1.61