### PR TITLE
Add `serde` feature to allow serializing Markov chains

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Test
-        run: cargo test
+        run: cargo test --all-features
 
       # This checks examples and benchmarks, which are not covered above.
       - name: Check all targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ serde = {version = "1", features = ["derive"], optional = true}
 [dev-dependencies]
 version-sync = "0.9.4"
 rand = "0.9"
+postcard = { version = "1.1.3", features = ["alloc"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub type Bigram<'a> = (&'a str, &'a str);
 ///
 /// [Markov chain]: https://en.wikipedia.org/wiki/Markov_chain
 /// [blog post]: https://blakewilliams.me/posts/generating-arbitrary-text-with-markov-chains-in-rust
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MarkovChain<'a> {
     #[cfg_attr(feature = "serde", serde(borrow))]
@@ -712,5 +712,27 @@ mod tests {
             chain.generate_with_rng(rng, 15),
             "A b bar a b x y y b bar x y y b x."
         );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_support() {
+        let mut chain = MarkovChain::new();
+        chain.learn("foo bar baz");
+
+        // Test that we can serialize and deserialize. Note that we
+        // cannot use `serde_json` here since JSON objects don't
+        // support non-string (we use string tuples for our keys).
+        let bytes = postcard::to_allocvec(&chain).unwrap();
+        assert_eq!(
+            bytes,
+            &[
+                0x01, 0x03, 0x66, 0x6f, 0x6f, 0x03, 0x62, 0x61, 0x72, 0x01, 0x03, 0x62, 0x61, 0x7a,
+                0x01, 0x03, 0x66, 0x6f, 0x6f, 0x03, 0x62, 0x61, 0x72,
+            ]
+        );
+
+        let deserialized_chain = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(chain, deserialized_chain);
     }
 }


### PR DESCRIPTION
Very simple change, but sadly not possible with the traditional serde ["derive for remote crate"](https://serde.rs/remote-derive.html), because the fields are private:
```rs
#[derive(Serialize, Deserialize)]
#[serde(remote = "MarkovChain")]
struct MarkovChainSerde<'a> {
    #[serde(borrow)]
    map: std::collections::HashMap<lipsum::Bigram<'a>, Vec<&'a str>>,
    #[serde(borrow)]
    keys: Vec<lipsum::Bigram<'a>>,
}
```
![image](https://github.com/user-attachments/assets/a54d4733-ac65-4f13-bc00-b63a318324d8)

So I figured I'd add serde itself as a feature instead of changing visibility.